### PR TITLE
chore: remove 'php artisan migrate' command 

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,7 +49,7 @@ then
 	ssh -i /root/.ssh/id_rsa -t $SSH_USER@$SSH_HOST "sudo chmod 775 -R $PATH_SOURCE"
 	ssh -i /root/.ssh/id_rsa -t $SSH_USER@$SSH_HOST "sudo chmod 777 -R $PATH_SOURCE/storage"
 	ssh -i /root/.ssh/id_rsa -t $SSH_USER@$SSH_HOST "sudo chmod 777 -R $PATH_SOURCE/public"
-	ssh -i /root/.ssh/id_rsa -t $SSH_USER@$SSH_HOST "cd $PATH_SOURCE && php artisan migrate && php artisan cache:clear && php artisan route:cache && php artisan config:cache"
+	ssh -i /root/.ssh/id_rsa -t $SSH_USER@$SSH_HOST "cd $PATH_SOURCE && php artisan cache:clear && php artisan route:cache && php artisan config:cache"
 
 	if [ ! -z "$COMMANDS" ];
 	then

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,6 @@ This project is fork from  [Charliex2/laravel-deploy-x](https://github.com/charl
 
 ## Default Artisan Commands
 ```
-php artisan migrate 
 php artisan cache:clear 
 php artisan route:cache
 php artisan config:cache


### PR DESCRIPTION
When the system is in production, there is a need to confirm whether you really want to execute the 'php artisan migrate' command. However, during deployment, this process runs in the background and remains in a pending state. With each deployment, the process queues up, maxing out CPU usage at 100%. This continues until the process is manually terminated